### PR TITLE
Install ca-certificates in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ RUN go build -o app
 RUN chmod +x app
 
 FROM alpine
+RUN apk add --update --no-cache ca-certificates
 COPY --from=build-env /go/src/github.com/ahume/delete-stalled-concourse-workers/app /app
 


### PR DESCRIPTION
If connecting to an instance over TLS, we need to trust the certificate.